### PR TITLE
[TASK] Adjust decoupling Party of Flow 3.0

### DIFF
--- a/Classes/Refactory/Login/Controller/LoginController.php
+++ b/Classes/Refactory/Login/Controller/LoginController.php
@@ -35,6 +35,12 @@ class LoginController extends AbstractAuthenticationController {
 		'html'  => 'TYPO3\Fluid\View\TemplateView',
 		'json'  => 'TYPO3\Flow\Mvc\View\JsonView');
 
+    /**
+     * @Flow\Inject
+     * @var  \TYPO3\Flow\I18n\Service
+     */
+    protected $i18nService;
+
 	/**
 	 * @var \TYPO3\Flow\I18n\Translator
 	 * @Flow\Inject
@@ -47,6 +53,12 @@ class LoginController extends AbstractAuthenticationController {
 	 * @param string $username
 	 */
 	public function loginAction($username = '') {
+        # Set locale based on Accept-Language
+        $detector = new \TYPO3\Flow\I18n\Detector();
+        $acceptLanguageHeader = $this->request->getHttpRequest()->getHeaders()->get('Accept-Language');
+        $language = $detector->detectLocaleFromHttpHeader($acceptLanguageHeader);
+        $this->i18nService->getConfiguration()->setCurrentLocale($language);
+
 		if ($this->authenticationManager->isAuthenticated()) {
 			if (isset($this->settings['authenticatedRedirect'])) {
 				$redirect = $this->settings['authenticatedRedirect'];

--- a/Classes/Refactory/Login/Controller/PasswordController.php
+++ b/Classes/Refactory/Login/Controller/PasswordController.php
@@ -53,6 +53,12 @@ class PasswordController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 	protected $userRepository;
 
 	/**
+	 * @var string
+	 * @Flow\Inject(setting="partyRepositoryClassName", package="Refactory.Login")
+	 */
+	protected $partyRepositoryClassName;
+
+	/**
 	 * Display reset a password request form
 	 */
 	public function resetRequestAction() {
@@ -80,7 +86,8 @@ class PasswordController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 		} else {
 			$account = $this->accountRepository->findByAccountIdentifierAndAuthenticationProviderName($identifier, 'DefaultProvider');
 			if ($account !== NULL) {
-				$person = $account->getParty();
+				$partyRepository = $this->objectManager->get($this->partyRepositoryClassName);
+				$person = $partyRepository->findOneHavingAccount($account);
 				$resetPasswordToken = $this->accountManagementService->generateResetPasswordTokenForParty($person, $this->request);
 			} else {
 				$person = $this->userRepository->findByPrimaryElectronicAddress($identifier)->getFirst();

--- a/Classes/Refactory/Login/Helpers/SecurityHelper.php
+++ b/Classes/Refactory/Login/Helpers/SecurityHelper.php
@@ -22,12 +22,26 @@ class SecurityHelper {
 	protected $securityContext;
 
 	/**
+	 * @var string
+	 * @Flow\Inject(setting="partyRepositoryClassName", package="Refactory.Login")
+	 */
+	protected $partyRepositoryClassName;
+
+	/**
+	 * @Flow\Inject
+	 * @var \TYPO3\Flow\Object\ObjectManagerInterface
+	 */
+	protected $objectManager;
+
+	/**
 	 * @return null
 	 */
 	public function getCurrentUser() {
 		$currentAccount = $this->getCurrentAccount();
 		if ($currentAccount != NULL) {
-			return $currentAccount->getParty();
+
+			$partyRepository = $this->objectManager->get($this->partyRepositoryClassName);
+			return $partyRepository->findOneHavingAccount($currentAccount);
 		}
 		return NULL;
 	}

--- a/Classes/Refactory/Login/ViewHelpers/AccountViewHelper.php
+++ b/Classes/Refactory/Login/ViewHelpers/AccountViewHelper.php
@@ -25,15 +25,31 @@ class AccountViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper 
 	protected $securityContext;
 
 	/**
+	 * @var string
+	 * @Flow\Inject(setting="partyRepositoryClassName", package="Refactory.Login")
+	 */
+	protected $partyRepositoryClassName;
+
+	/**
+	 * @Flow\Inject
+	 * @var \TYPO3\Flow\Object\ObjectManagerInterface
+	 */
+	protected $objectManager;
+
+	/**
 	 * @param string $propertyPath
 	 * @return string
 	 */
-	public function render($propertyPath = 'party.name') {
+	public function render($propertyPath = 'name') {
+
+		$partyRepository = $this->objectManager->get($this->partyRepositoryClassName);
+
 		$tokens = $this->securityContext->getAuthenticationTokens();
 
 		foreach ($tokens as $token) {
 			if ($token->isAuthenticated()) {
-				return (string)\TYPO3\Flow\Reflection\ObjectAccess::getPropertyPath($token->getAccount(), $propertyPath);
+				$person = $partyRepository->findOneHavingAccount($token->getAccount());
+				return (string)\TYPO3\Flow\Reflection\ObjectAccess::getPropertyPath($person, $propertyPath);
 			}
 		}
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -15,6 +15,7 @@ TYPO3:
 
 Refactory:
   Login:
+    partyRepositoryClassName: 'TYPO3\Party\Domain\Repository\PartyRepository'
     tokenExpiration: 14400 # in seconds
 #    image: 'resource://Refactory.Login/Public/Images/ApplicationLogo.png'
 #    styles:

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,23 @@
         "psr-0": {
             "Refactory\\Login": "Classes"
         }
+    },
+    "extra": {
+        "applied-flow-migrations": [
+            "TYPO3.Flow-201212051340",
+            "TYPO3.FLOW3-201201261636",
+            "TYPO3.Fluid-201205031303",
+            "TYPO3.FLOW3-201205292145",
+            "TYPO3.FLOW3-201206271128",
+            "TYPO3.FLOW3-201209201112",
+            "TYPO3.Flow-201209251426",
+            "TYPO3.Flow-201211151101",
+            "TYPO3.Flow-201310031523",
+            "TYPO3.Flow-201405111147",
+            "TYPO3.Fluid-20141113120800",
+            "TYPO3.Flow-20141113121400",
+            "TYPO3.Fluid-20141121091700",
+            "TYPO3.Fluid-20150214130800"
+        ]
     }
 }


### PR DESCRIPTION
In Flow 3.0, using $account->getParty() was deprecated and developers
are encouraged to fetch the Person through their own PartyRepository.
This change adapts to the new behaviour.

By default, the Party is retrieved through
\TYPO3\Party\Domain\Repository\PartyRepository, but this can be changed
to any other repository having a findOneHavingAccount method.
